### PR TITLE
ci: 🎡 デバッグ用に echo に代替していた命令を npx cypress に戻した

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Cypress を実行する（Webにデータを記録する）
         if: ${{ steps.get_branch_name.outputs.branch_name == 'main' || steps.get_branch_name.outputs.branch_name == 'development' }}
         run: |
-          echo "npx cypress run --parallel --browser firefox --record --key ${{ secrets.CYPRESS_RECORD_KEY }}"
+          npx cypress run --parallel --browser firefox --record --key ${{ secrets.CYPRESS_RECORD_KEY }}
       - name: Cypress を実行する（Webにデータを記録しない）
         if: ${{ steps.get_branch_name.outputs.branch_name != 'main' && steps.get_branch_name.outputs.branch_name != 'development' }}
         run: |
-          echo "npx cypress run --parallel --browser firefox --record false"
+          npx cypress run --parallel --browser firefox --record false

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -60,4 +60,4 @@ jobs:
       - name: Cypress を実行する（Webにデータを記録しない）
         if: ${{ steps.get_branch_name.outputs.branch_name != 'main' && steps.get_branch_name.outputs.branch_name != 'development' }}
         run: |
-          npx cypress run --parallel --browser firefox --record false
+          npx cypress run --browser firefox --record false


### PR DESCRIPTION
CI では `--parallel` を有効にすると落ちる。

```
You passed the --ci-build-id, --group, --tag, or --parallel flag without also passing the --record flag.

The --parallel flag you passed was: true

These flags can only be used when recording to the Cypress Dashboard service.

https://on.cypress.io/record-params-without-recording
```
