### PR TITLE
v3.0.0

### DIFF
--- a/.github/workflows/push_docker_image_in_dispatch.yml
+++ b/.github/workflows/push_docker_image_in_dispatch.yml
@@ -1,0 +1,51 @@
+name: GitHub Container Registry にイメージをプッシュする（手動）
+on:
+  - workflow_dispatch
+env:
+  TZ: '/usr/share/zoneinfo/Asia/Tokyo'
+  IMAGE_NAME: pixhost_downloader
+jobs:
+  build_and_push:
+    name: Docker のイメージをビルドして GitHub Container Registry にプッシュする（手動）
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Git のタグ名 (vX.Y.Z) を Docker 用のタグ名 (X.Y.Z) に変換して変数に保存する
+        id: set_docker_tag_variable
+        run: |
+          GIT_TAG=$(git describe --tags --abbrev=0)
+          DOCKER_TAG="${GIT_TAG//v/}"
+          echo "::set-output name=docker_tag::${DOCKER_TAG}"
+      - name: GitHub Container Registry にログインする
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: hostname の確認
+        id: this_hostname
+        run: |
+          echo "::set-output name=hostname::$(hostname)"
+      - name: イメージをビルドして GitHub Container Registry にプッシュする
+        if: ${{ steps.this_hostname.outputs.hostname != 'docker-desktop' }} # act でローカル実行した場合は push しない
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          path: Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.set_docker_tag_variable.outputs.docker_tag }}
+      - name: CI 成功時に実行される Step
+        if: success()
+        run: |
+          echo '[LOG] Docker イメージ のプッシュに成功しました'
+      - name: CI 失敗時に実行される Step
+        if: failure()
+        run: |
+          echo '[LOG] Docker イメージ のプッシュに失敗しました'

--- a/.github/workflows/push_docker_image_in_dispatch.yml
+++ b/.github/workflows/push_docker_image_in_dispatch.yml
@@ -17,7 +17,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Git のタグ名 (vX.Y.Z) を Docker 用のタグ名 (X.Y.Z) に変換して変数に保存する
         id: set_docker_tag_variable
+        # git fetch --prune --unshallow しないと main ブランチを持ってきてくれず、タグが取得できない
         run: |
+          git fetch --prune --unshallow
           GIT_TAG=$(git describe --tags --abbrev=0)
           DOCKER_TAG="${GIT_TAG//v/}"
           echo "::set-output name=docker_tag::${DOCKER_TAG}"

--- a/.github/workflows/push_docker_image_in_tag_push.yml
+++ b/.github/workflows/push_docker_image_in_tag_push.yml
@@ -1,0 +1,54 @@
+name: GitHub Container Registry にイメージをプッシュする
+on:
+  push:
+    # タグ付けがなされたときだけ push する（そうしないと set_docker_tag_variable でタグ名が取得できない）
+    tags:
+      - 'v*.*.*'
+env:
+  TZ: '/usr/share/zoneinfo/Asia/Tokyo'
+  IMAGE_NAME: pixhost_downloader
+jobs:
+  build_and_push:
+    name: Docker のイメージをビルドして GitHub Container Registry にプッシュする
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Git のタグ名 (vX.Y.Z) を Docker 用のタグ名 (X.Y.Z) に変換して変数に保存する
+        id: set_docker_tag_variable
+        run: |
+          GIT_TAG=$(git tag --sort=-creatordate | sed -n 1p)
+          DOCKER_TAG="${GIT_TAG//v/}"
+          echo "::set-output name=docker_tag::${DOCKER_TAG}"
+      - name: GitHub Container Registry にログインする
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: hostname の確認
+        id: this_hostname
+        run: |
+          echo "::set-output name=hostname::$(hostname)"
+      - name: イメージをビルドして GitHub Container Registry にプッシュする
+        if: ${{ steps.this_hostname.outputs.hostname != 'docker-desktop' }} # act でローカル実行した場合は push しない
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          path: Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ steps.set_docker_tag_variable.outputs.docker_tag }}
+      - name: CI 成功時に実行される Step
+        if: success()
+        run: |
+          echo '[LOG] Docker イメージ のプッシュに成功しました'
+      - name: CI 失敗時に実行される Step
+        if: failure()
+        run: |
+          echo '[LOG] Docker イメージ のプッシュに失敗しました'

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Options:
 
 ### イメージを作成
 - まずはイメージを作成する
-- 266MB と結構大きなサイズなので、ここは見直したい
+- 200MB と結構大きなサイズなので、ここは見直したい
 
 ```bash
 $ git clone https://github.com/nikukyugamer/pixhost-downloader
@@ -64,6 +64,16 @@ $ docker container run --rm -e LOCAL_UID=$(id -u $USER) -e LOCAL_GID=$(id -g $US
 
 ```bash
 $ docker image rm pixhost_downloader:latest
+```
+
+# 使い方（Docker で実行する場合、かつ、イメージはリモートリポジトリからもってくる場合）
+- おそらくこれが一番楽です
+- 「**使い方（Docker で実行する場合、かつ、イメージを自分でビルドする場合）**」の「**コマンドを実行する**」の箇所において、対象のイメージ指定を `ghcr.io/nikukyugamer/pixhost_downloader:latest` に変えるだけです
+- コマンド例は次のとおりです
+  - 条件等は「**使い方（Docker で実行する場合、かつ、イメージを自分でビルドする場合）**」と同じ
+
+```bash
+$ docker container run --rm -e LOCAL_UID=$(id -u $USER) -e LOCAL_GID=$(id -g $USER) -v $HOME/HOZON_SURU_DIRECTORY:/tmp/pixhost_downloader ghcr.io/nikukyugamer/pixhost_downloader:latest -u https://pixhost.to/show/228/126849268_picturepub-iskra-lawrence-006.jpg -d /tmp/pixhost_downloader
 ```
 
 # Cypress


### PR DESCRIPTION
## 機能追加・改修

- ci: 🎡 GitHub Container Registry に Docker のイメージをプッシュするようにした @nikukyugamer (#65)

## CI

- ci: 🎡 git tag をするために fetch して対象ブランチを取得するようにした @nikukyugamer (#66)

## ドキュメント

- docs: ✏️ ghcr.io からイメージを持ってくる場合の Docker 実行例ドキュメントを追加した @nikukyugamer (#67)

## Docker

- docs: ✏️ ghcr.io からイメージを持ってくる場合の Docker 実行例ドキュメントを追加した @nikukyugamer (#67)
- ci: 🎡 GitHub Container Registry に Docker のイメージをプッシュするようにした @nikukyugamer (#65)
